### PR TITLE
feat: Add vs code rest-client plugin

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -4,6 +4,7 @@
     "ms-vscode.vscode-typescript-tslint-plugin",
     "esbenp.prettier-vscode",
     "graphql.vscode-graphql",
-    "prisma.prisma"
+    "prisma.prisma",
+    "humao.rest-client"
   ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,11 @@
+{
+    "rest-client.environmentVariables": {
+        "$shared": {
+        },
+        "local": {
+            "host": "localhost:3000"
+        },
+        "production": {
+        }
+    }
+}

--- a/requests/posts.http
+++ b/requests/posts.http
@@ -1,0 +1,51 @@
+### List posts
+GET http://{{host}}/posts/
+
+
+
+### Find post
+# @name findPost
+# @prompt postId
+GET http://{{host}}/posts/{{postId}}
+
+
+
+
+### Create posts
+# @prompt title
+# @prompt content
+# @prompt published must be true or false
+# @prompt authorId
+POST http://{{host}}/posts/
+Content-Type: application/json
+
+{
+    "title": "{{title}}",
+    "content": "{{content}}",
+    "published": {{published}},
+    "authorId": "{{authorId}}"
+}
+
+
+
+
+### Update posts
+@postId = {{findPost.response.body.$.id}}
+@authorId = {{findPost.response.body.$.authorId}}
+# @prompt title
+# @prompt content
+# @prompt published must be true or false
+PATCH http://{{host}}/posts/{{postId}}
+Content-Type: application/json
+
+{
+    "title": "{{title}}",
+    "content": "{{content}}",
+    "published": {{published}},
+    "authorId": "{{authorId}}"
+}
+
+
+### Delete post
+# @prompt postId
+DELETE http://{{host}}/posts/{{postId}}

--- a/requests/users.http
+++ b/requests/users.http
@@ -1,0 +1,55 @@
+@hostname = localhost
+@port = 3000
+@host = {{hostname}}:{{port}}
+
+
+### List users
+GET http://{{host}}/users/
+
+
+
+### Find user
+# @name findUser
+# @prompt userId
+GET http://{{host}}/users/{{userId}}
+
+
+
+### Create user
+# @prompt email
+# @prompt firstname
+# @prompt lastname
+# @prompt role ADMIN or USER
+# @prompt postsIds 
+POST http://{{host}}/users/
+Content-Type: application/json
+
+{
+    "email": "{{email}}",
+    "firstname": "{{firstname}}",
+    "lastname": "{{lastname}}",
+    "role": "{{role}}",
+    "posts": {{postsIds}}
+}
+
+
+
+
+### Update user
+@userId = {{findUser.response.body.$.id}}
+# @prompt firstname
+# @prompt lastname
+# @prompt role ADMIN or USER
+PATCH http://{{host}}/users/{{userId}}
+Content-Type: application/json
+
+{
+    "firstname": "{{firstname}}",
+    "lastname": "{{lastname}}",
+    "role": "{{role}}"
+}
+
+
+### Delete user
+# @prompt userId
+DELETE http://{{host}}/users/{{userId}}


### PR DESCRIPTION
This PR adds the [rest-client](https://marketplace.visualstudio.com/items?itemName=humao.rest-client) to make it easier to test endpoints manually. 

It's possible to run requests directly from vs code and change environments between local and production, as can be seen in  the screenshots:

<img width="412" alt="Screenshot 2023-07-10 at 15 37 06" src="https://github.com/saulolso/nestjs-prisma-starter/assets/119562/08fdc43d-0901-43b4-867b-fc5d00bbe3e1">


<img width="1570" alt="Screenshot 2023-07-10 at 15 33 56" src="https://github.com/saulolso/nestjs-prisma-starter/assets/119562/79524a94-c29c-47a0-93b2-7200ddb2e736">


<img width="798" alt="Screenshot 2023-07-10 at 15 37 10" src="https://github.com/saulolso/nestjs-prisma-starter/assets/119562/77635d2c-d749-45b0-a0bc-88ec0e578db6">

